### PR TITLE
Added a tiny overlap (epsilon) to subtractions

### DIFF
--- a/cyl_head_bolt.scad
+++ b/cyl_head_bolt.scad
@@ -20,6 +20,10 @@
 include <data-access.scad>;                // database lookup functions
 include <data-metric_cyl_head_bolts.scad>; // database 
 
+/* Constants */
+
+e = 0.01; // epsilon for SCAD artifact removal
+2e= 0.02; // adds a tiny overlap to subtrahends
 
 // =============================
 // -- through hole for screws --
@@ -41,7 +45,7 @@ module hole_through(
 	union() {
 		translate([0, 0, -l/2-h]) cylinder(r=(orad+cld/2), h=l,  center=true);
 		if (h>0)
-			translate([0,0,-h/2]) cylinder(r=(head_rad+hcld/2),h=h, center=true);
+			translate([0,0,-h/2]) cylinder(r=(head_rad+hcld/2),h=h+e, center=true);
 	}
 }
 // -- end of hole_through module
@@ -175,7 +179,7 @@ module screw(
 
 	difference() {
 		translate([0,0,head_height/2]) cylinder(r=head_rad, h=head_height, center=true);
-		translate([0,0,head_height]) key_slot(k=key_width, l=key_depth);
+		translate([0,0,head_height+e]) key_slot(k=key_width, l=key_depth+e);
 	}
 
 }

--- a/examples.scad
+++ b/examples.scad
@@ -27,10 +27,10 @@ include <materials.scad>;
 difference() {
 	translate([-15, -15, 0]) cube([80, 30, 50]);
 	rotate([180,0,0]) nutcatch_parallel("M5", l=5);
-	translate([0, 0, 50]) hole_through(name="M5", l=50+5, cl=0.1, h=10, hcl=0.4);
-	translate([55, 0, 9]) nutcatch_sidecut("M8", l=100, clk=0.1, clh=0.1, clsl=0.1);
-	translate([55, 0, 50]) hole_through(name="M8", l=50+5, cl=0.1, h=10, hcl=0.4);
-	translate([27.5, 0, 50]) hole_threaded(name="M5", l=60);
+	translate([0, 0, 50+e]) hole_through(name="M5", l=50+5, cl=0.1, h=10, hcl=0.4);
+	translate([55, 0, 9+e]) nutcatch_sidecut("M8", l=100, clk=0.1, clh=0.1, clsl=0.1);
+	translate([55, 0, 50+e]) hole_through(name="M8", l=50+5, cl=0.1, h=10, hcl=0.4);
+	translate([27.5, 0, 50+e]) hole_threaded(name="M5", l=60);
 }
 
 


### PR DESCRIPTION
so that OpenSCAD doesn't render artifacts in preview mode

So this,
![nutsboltshead-1](https://user-images.githubusercontent.com/1202892/48885009-6890e500-ee2f-11e8-8531-a3f9dd14eb6c.png)
becomes this
![nutsboltshead](https://user-images.githubusercontent.com/1202892/48885011-69c21200-ee2f-11e8-8b91-341e1c6e69e1.png)


I have used your library in [Rosalind](https://gitlab.com/d-e/rosalind), the new RepRap printer I'm building, and throughout that code I'm trying to make sure the preview does not have these "exact subtraction" artifacts. This is even more important for the assembly instructions as I need color rendering (i.e. can't use F6). You can still set e=0 to get the old behavior back.

I always believe it's better to just use upstream than keeping downstream forks so if you agree with the change I'd be glad if you could merge.